### PR TITLE
Update stale endpoint from '3hourly' to 'hourly'

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,14 +46,14 @@ def test_forecasts_daily():
     assert 'temp_max' in fd[0]
     assert 'short_text' in fd[0]
 
-def test_forecasts_3hourly():
-    f3 = w1.forecasts_3hourly()
 
-    assert len(f3) >= 16
-    assert 'time' in f3[0]
-    assert 'temp' in f3[0]
-    assert 'icon_descriptor' in f3[0]
+def test_forecasts_hourly():
+    f1 = w1.forecasts_hourly()
 
+    assert len(f1) >= 72
+    assert 'time' in f1[0]
+    assert 'temp' in f1[0]
+    assert 'icon_descriptor' in f1[0]
 
 w1a = api.WeatherApi(search='some+unknown+place')
 
@@ -75,8 +75,8 @@ def test_forecast_rain_unknown():
 def test_forecasts_daily_unknown():
     assert w1a.forecasts_daily() is None
 
-def test_forecasts_3hourly_unknown():
-    assert w1a.forecasts_3hourly() is None
+def test_forecasts_hourly_unknown():
+    assert w1a.forecasts_hourly() is None
 
 
 w2 = api.WeatherApi() 

--- a/weather_au/__init__.py
+++ b/weather_au/__init__.py
@@ -46,8 +46,8 @@ PLACES_URL = 'http://www.bom.gov.au/places/{state}/{location}'
 M_PLACES_URL = 'http://m.bom.gov.au/{state}/{location}'
 
 PLACES_USER_AGENT = \
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 ' \
-    '(KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' \
+    '(KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
 
 # UV Index Forecast - Local Noon
 UV_INDEX_URL = 'http://reg.bom.gov.au/fwo/IDY00508.gif'

--- a/weather_au/api.py
+++ b/weather_au/api.py
@@ -19,7 +19,7 @@ class WeatherApi:
 
     Data is in metric units unless otherwise indicated.
 
-    forecasts/3-hourly checks for a six character geohash. Search return 7 characters.
+    forecasts/hourly checks for a six character geohash. Search return 7 characters.
 
     # click on warning
     # https://api.weather.bom.gov.au/v1/warnings/IDV36310?cbts=1568014740
@@ -30,7 +30,7 @@ class WeatherApi:
     API_FORECAST_RAIN = API_BASE + 'forecast/rain'
     API_WARNINGS = API_BASE + 'warnings'
     API_FORECAST_DAILY = 'forecasts/daily'
-    API_FORECAST_3HOURLY = 'forecasts/3-hourly'
+    API_FORECAST_HOURLY = 'forecasts/hourly'
     API_OBSERVATIONS = 'observations'
     SEARCH = 'locations?search='
     ACKNOWLEDGEMENT = 'Data courtesy of the Australian Bureau of Meteorology (https://api.weather.bom.gov.au)'
@@ -235,9 +235,9 @@ class WeatherApi:
         return self.api('forecasts/daily')
 
 
-    def forecasts_3hourly(self):
+    def forecasts_hourly(self):
         """
-        Example https://api.weather.bom.gov.au/v1/locations/r1r143/forecasts/3-hourly
+        Example https://api.weather.bom.gov.au/v1/locations/r1r143/forecasts/hourly
 
         [{rain:{amount:{min, max, units}, chance},
                temp,
@@ -255,7 +255,7 @@ class WeatherApi:
 
         A six character geohash is expected.
         """
-        return self.api('forecasts/3-hourly')
+        return self.api('forecasts/hourly')
 
 
     def __repr__(self):

--- a/weather_au/summary.py
+++ b/weather_au/summary.py
@@ -7,7 +7,7 @@ class Summary:
     that is similar to https://weather.bom.gov.au/
 
     TODO: validate the text and values for max_temp, overnight_min_temp, 
-          chance_of_rain based on when the website switches from one form to anoth.
+          chance_of_rain based on when the website switches from one form to another.
     """
 
     def __init__(self, geohash=None, search=None, debug=0):
@@ -21,7 +21,7 @@ class Summary:
         self.observations        = self.api.observations()
         self.forecast_rain       = self.api.forecast_rain()
         self.forecasts_daily     = self.api.forecasts_daily()
-        self.forecasts_3hourly   = self.api.forecasts_3hourly()
+        self.forecasts_hourly    = self.api.forecasts_hourly()
 
 
     def summary(self):


### PR DESCRIPTION
The underlying BOM Api no longer support the 'forecasts/3-hourly' endpoint. Instead they have a 'forecasts/hourly' endpoint with the same data. 

The tests were failing with the old USER-AGENT value, it might be temporary (or it might not), either way I swapped out the USER-AGENT value so that the tests passed. 