### PR TITLE
Readme fix + examples fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Where possible WeatherApi, should be used as it uses an API rather than scraping
 ### Sample for Parkville in Melbourne Vic Australia
 
 ```python3
-from weather import place, observations, uv_index
+from weather_au import place, observations, uv_index
 
 # Parse http://www.bom.gov.au/places/vic/parkville
 place_data = place.Place('vic', 'parkville')

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ This information has been reverse engineered from the [beta website](https://wea
 import sys
 from weather_au import api
 
-w = api.WeatherApi(search='parkville+vic', debug=0)
+w = api.WeatherApi(search='3052', debug=0)
 
 location = w.location()
 
 # check if the search produced a result (other methods will also return None if the search fails).
 if location is None:
-    sys.exit('Search failed for location ' + loc)
+    sys.exit('Search failed for location ' + location)
 
 print(f"\nLocation: {location['name']} {location['state']}, timezone:{location['timezone']}\n")
 
@@ -48,8 +48,8 @@ print(f"\nObservations (temp): {observations['temp']:2}")
 forecast_rain = w.forecast_rain()
 print(f"Forecast Rain:       amount:{forecast_rain['amount']}, chance:{forecast_rain['chance']}")
 
-print('\n3 Hourly:')
-for f in w.forecasts_3hourly():
+print('\nHourly:')
+for f in w.forecasts_hourly():
     print(f"{f['time']} temp:{f['temp']:2}, {f['icon_descriptor']}")
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ This information has been reverse engineered from the [beta website](https://wea
 import sys
 from weather_au import api
 
-w = api.WeatherApi(search='3052', debug=0)
+loc = '3052'
+w = api.WeatherApi(search=loc, debug=0)
 
 location = w.location()
 
 # check if the search produced a result (other methods will also return None if the search fails).
 if location is None:
-    sys.exit('Search failed for location ' + location)
+    sys.exit('Search failed for location ' + loc)
 
 print(f"\nLocation: {location['name']} {location['state']}, timezone:{location['timezone']}\n")
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The purpose of these modules is to fetch weather data from various Australian Bu
 
 ## Weather API
 
-Fetches data from the API's at `api.weather.bom.gov.au` (e.g. [Parkville 3-hourly forecast](https://api.weather.bom.gov.au/v1/locations/r1r143/forecasts/3-hourly)).
+Fetches data from the API's at `api.weather.bom.gov.au` (e.g. [Parkville hourly forecast](https://api.weather.bom.gov.au/v1/locations/r1r143/forecasts/hourly)).
 
 This information has been reverse engineered from the [beta website](https://weather.bom.gov.au/) with no information about future access arrangements, content or availability.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ for f in w.forecasts_hourly():
 ```python3
 from weather_au import summary
 
-print(summary.Summary(search='parkville+vic'))
+print(summary.Summary(search='parkville').summary_text())
 ```
 
 

--- a/examples/api.py
+++ b/examples/api.py
@@ -1,7 +1,7 @@
 import sys
 from weather_au import api
 
-loc = 'endeavour-hills+vic'
+loc = '3802'
 w = api.WeatherApi(search=loc, debug=0)
 
 print(repr(w))
@@ -48,6 +48,6 @@ for f in w.forecasts_daily():
     print(f"{f['date']} temp_min:{temp_min}, temp_max:{temp_max}, {f['short_text']}")
 
 
-print('\n3 Hourly:')
-for f in w.forecasts_3hourly():
+print('\nHourly:')
+for f in w.forecasts_hourly():
     print(f"{f['time']} temp:{f['temp']:2}, {f['icon_descriptor']}")

--- a/examples/summary.py
+++ b/examples/summary.py
@@ -3,6 +3,6 @@ sys.path.append(os.path.abspath('.'))
 
 from weather_au import summary
 
-w = summary.Summary(search='parkville+vic')
+w = summary.Summary(search='3052')
 
 print(w.summary_text())


### PR DESCRIPTION
Due to the recent 3hourly -> hourly api change there were a few fixes needed in the examples and readme.

also i found the examples using `suburb+state` syntax in `search` parameter for the `https://api.weather.bom.gov.au/v1/locations` api now do not return any results from the bom api, I have replaced these with postcodes so the examples now work as intended

Cool module and keen to see it evolve!