### PR TITLE
allow a dash as the first char of a search string for lat/lon searches

### DIFF
--- a/weather_au/api.py
+++ b/weather_au/api.py
@@ -94,8 +94,9 @@ class WeatherApi:
         if search == '':
             return []
 
-        # The search API doesn't like the dash character.
-        search = search.replace('-', '+')
+        # The search API doesn't like the dash character
+        # unless its a lat/lon search with a negative latitude.
+        search = search[0] + search[1:].replace('-', '+')
 
         data = self._fetch_json(f'{self.API_BASE}/{self.SEARCH}{search}')
 


### PR DESCRIPTION
Searches for locations by lat/lon coords fail because the dash denoting a negative latitude gets replaced with a '+', e.g.

`Fetching: https://api.weather.bom.gov.au/v1/locations?search=+33.06,152.66`
`WeatherApi(geohash=None, search='', debug=1), timestamp=2024-03-11T06:57:20Z`
`Search failed for location -33.06,152.66
`

This PR allows a dash as the first character in the search string, but still replaces any subsequent dashes with plus signs.
